### PR TITLE
Added escape method to protect templates from xss, added ability to add a description for a panel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In this project, it was decided to disable x-debug overlay for var_dumps. This m
 
     $fireBug = \UA1Labs\Fire\Bug::get();
     $debuggerPanel = $fireBug->getPanel(\UA1Labs\Fire\Bug\Panel\Debugger::ID);
-    $fireBug->enableXDebugOverlay();
+    $debuggerPanel->enableXDebugOverlay();
 
 ### Creating And Registering Your Own Panel
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,9 @@
 # Release Changes
+
+* 2.1.0
+    * Update the render method logic in the debugger panel to use $this->name instead of self::NAME.
+    * Add the panel ID as a class to the HTML markup of the debug panel.
+    * Added new escape method to panels that allows you to escape variables being echoed on the view.
 * 2.0.0
     * Added UA1Labs to namespace
     * Bring code base up to PSR-2 compliance

--- a/UA1Labs/Fire/Bug/Panel.php
+++ b/UA1Labs/Fire/Bug/Panel.php
@@ -35,6 +35,13 @@ abstract class Panel
     protected $name;
 
     /**
+     * The description of the panel.
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
      * A path to a pthml template.
      *
      * @var string
@@ -53,6 +60,7 @@ abstract class Panel
         $this->id = $id;
         $this->name = $name;
         $this->template = $template;
+        $this->description = '';
     }
 
     /**
@@ -86,6 +94,26 @@ abstract class Panel
     }
 
     /**
+     * Sets the description for the given panel.
+     *
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Retrusn the description for the given panel.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
      * Returns a label.
      *
      * @param  string $content The content of the label
@@ -95,11 +123,11 @@ abstract class Panel
      */
     public function renderLabel($content, $class = '', $style = '')
     {
-        $styleAttr = ($style) ? ' style="' . $style . '"' : '';
+        $styleAttr = ($style) ? ' style="' . $this->escape($style) . '"' : '';
         $classes = ($class) ? ' ' . $class : '';
         $renderLabel = '';
-        $renderLabel .= '<span class="fs-label' . $classes . '"' . $style . '>';
-        $renderLabel .= $content;
+        $renderLabel .= '<span class="fs-label' . $this->escape($classes) . '"' . $styleAttr . '>';
+        $renderLabel .= $this->escape($content);
         $renderLabel .= '</span>';
         return $renderLabel;
     }
@@ -114,12 +142,12 @@ abstract class Panel
      */
     public function renderSeparator($bold = true, $class = '', $style = '')
     {
-        $styleAttr = ($style) ? ' style="' . $style . '"' : '';
+        $styleAttr = ($style) ? ' style="' . $this->escape($style) . '"' : '';
         $classes = ($class) ? ' ' . $class : '';
         if ($bold) {
-            return '<hr class="fs-hr' . $classes . '"' . $styleAttr . '>';
+            return '<hr class="fs-hr' . $this->escape($classes) . '"' . $styleAttr . '>';
         } else {
-            return '<hr class="fs-hr-dotted' . $classes . '"' . $styleAttr . '>';
+            return '<hr class="fs-hr-dotted' . $this->escape($classes) . '"' . $styleAttr . '>';
         }
     }
 
@@ -139,7 +167,7 @@ abstract class Panel
         $renderCode .= ' | ';
         $renderCode .= '<span class="fs-pre-wrap">wrap</span>';
         $renderCode .= '<pre class="debugger'. $darkClass . '">';
-        $renderCode .= htmlspecialchars($code);
+        $renderCode .= $this->escape($code);
         $renderCode .= '</pre>';
         $renderCode .= '</span>';
 
@@ -176,21 +204,32 @@ abstract class Panel
         $renderTrace = '';
         $renderTrace .= '<span class="fs-label">';
         foreach ($debug_backtrace as $index => $trace) {
-            $renderTrace .= '#' . $index . ' ';
+            $renderTrace .= '#' . $this->escape($index) . ' ';
             if (!empty($trace['file'])) {
-                $renderTrace .= $trace['file'];
+                $renderTrace .= $this->escape($trace['file']);
             }
             if (!empty($trace['line'])) {
-                $renderTrace .= '(' . $trace['line'] . ') ';
+                $renderTrace .= '(' . $this->escape($trace['line']) . ') ';
             }
             if (!empty($trace['class'])) {
-                $renderTrace .= $trace['class'] . '::';
+                $renderTrace .= $this->escape($trace['class']) . '::';
             }
-            $renderTrace .= $trace['function'] . '()'
+            $renderTrace .= $this->escape($trace['function']) . '()'
                 . '<br>';
         }
         $renderTrace .= '</span>';
         return $renderTrace;
+    }
+
+    /**
+     * Escapes content to prevent XSS attacks.
+     *
+     * @param string $val
+     * @return string
+     */
+    public function escape($val)
+    {
+        return htmlspecialchars($val, ENT_COMPAT | ENT_HTML401, 'UTF-8');
     }
 
     /**

--- a/UA1Labs/Fire/Bug/Panel/Debugger.php
+++ b/UA1Labs/Fire/Bug/Panel/Debugger.php
@@ -26,8 +26,6 @@ class Debugger extends Panel
 {
 
     const ID = 'debugger';
-    const NAME = 'Debuggers {{count}}';
-    const TEMPLATE = '/debugger.phtml';
 
     /**
      * If true, allows xdebug overlays in var_dump outputs.
@@ -48,7 +46,13 @@ class Debugger extends Panel
      */
     public function __construct()
     {
-        parent::__construct(self::ID, self::NAME, __DIR__ . self::TEMPLATE);
+        parent::__construct(self::ID, 'Debuggers {{count}}', __DIR__ . '/debugger.phtml');
+        $this->setDescription(
+            'This panel shows debug logs that were invoked using the debugger() function. ' .
+            'The debugger() function is similar to var_dump() but will display the inspected ' .
+            'variable in the panel below. The debug log will include a stack trace and ' .
+            'the var_dump output.'
+        );
         $this->debuggers = [];
     }
 
@@ -93,7 +97,7 @@ class Debugger extends Panel
             ini_set('xdebug.overload_var_dump', 'off');
         }
         $debuggerCount = count($this->debuggers);
-        $this->setName(str_replace('{{count}}', '{' . $debuggerCount . '}', self::NAME));
+        $this->setName(str_replace('{{count}}', '{' . $debuggerCount . '}', $this->name));
         parent::render();
     }
 }

--- a/UA1Labs/Fire/Bug/panel-top.phtml
+++ b/UA1Labs/Fire/Bug/panel-top.phtml
@@ -1,3 +1,6 @@
-<div class="fs-section fs-debugger-statements closed">
-    <h3 class="fs-title"><?php echo $this->name; ?><span class="fs-openCloseBtn"></span></h3>
+<div class="fs-section closed debug-panel-<?php echo $this->escape(strtolower($this->id)); ?>">
+    <h3 class="fs-title"><?php echo $this->escape($this->name); ?><span class="fs-openCloseBtn"></span></h3>
     <div class="fs-content">
+    <?php if ($this->description) { ?>
+    <span class="fs-description"><?php echo $this->escape($this->description); ?></span>
+    <?php } ?>

--- a/UA1Labs/Fire/firebug.phtml
+++ b/UA1Labs/Fire/firebug.phtml
@@ -58,6 +58,14 @@
         line-height: 24px;
         font-weight: 800;
     }
+    .fs-debug-panel .fs-description {
+        color: #464646;
+        display: block;
+        margin: 0 0 20px 0;
+        font-weight: 400;
+        border: 1px dotted #464646;
+        padding: 10px;
+    }
     .fs-debug-panel hr.fs-hr {
         margin: 25px 0 25px 0;
         color: #464646;
@@ -218,9 +226,9 @@
 </script>
 
 <div class="fs-debug-panel">
-    <h1 class="fs-title"><?php echo $this->getName(); ?></h1>
+    <h1 class="fs-title"><?php echo $this->escape($this->getName()); ?></h1>
     <?php if ($loadTime) { ?>
-        <span class="fs-label" style="text-align: right; color: #ececec;"><?php echo $loadTime; ?> milliseconds</span>
+        <span class="fs-label" style="text-align: right; color: #ececec;"><?php echo $this->escape($loadTime); ?> milliseconds</span>
     <?php } ?>
     <?php
         foreach ($this->getPanels() as $panel) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ua1-labs/firebug",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "An expandable PHP debugger panel.",
     "license": "MIT",
     "authors": [
@@ -21,7 +21,9 @@
         "ua1"
     ],
     "type": "library",
-    "require": {},
+    "require": {
+        "php": ">7.1.0"
+    },
     "require-dev": {
         "ua1-labs/firetest": "2.*"
     },


### PR DESCRIPTION
This PR includes:

* Update the render method logic in the debugger panel to use $this->name instead of self::NAME.
* Add the panel ID as a class to the HTML markup of the debug panel.
* Add htmlspecialchars('text', ENT_COMPAT \| ENT_HTML401, 'UTF-8'); to make echo values safe.
* Update XDebug documentation to to use $debuggerPanel to re-enable XDebug Overlay rather than $fireBug