### PR TITLE
Adding panel ordering capability

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release Changes
 
+* 2.2.0
+    * Added the ability to configure the order in which panels would be displayed. ie Bug::setPanelOrder().
 * 2.1.0
     * Update the render method logic in the debugger panel to use $this->name instead of self::NAME.
     * Add the panel ID as a class to the HTML markup of the debug panel.
@@ -8,48 +10,3 @@
     * Added UA1Labs to namespace
     * Bring code base up to PSR-2 compliance
     * Pull in FireTest 2.0 and update broken tests
-* 1.8.1
-    * Fix renderCode() so that it doesn't call htmlspecialchars() on entire panel.
-* 1.8.0
-    * Remove renderHtml() and update renderCode() to use htmlspecialchars() around the code.
-    * Update debugger(debug, exit = false) to use exitNow to allow a user to render the debug panel and exit the execution.
-* 1.7.2
-    * Update the debugger.phtml panel to use the new rendering helpers.
-* 1.7.1
-    * Fix issue with all pre's being 200px
-* 1.7.0
-    * For pre tags, add max-height and functionality to reveal entire code.
-    * Fix font-weight issues for p tags within panels.
-* 1.6.1
-    * Adjust CSS to target font-weight: normal for all elements in panel.
-* 1.6.0
-    * Add ability to renderSeparator() and renderLabel() within a panel.
-* 1.5.0
-    * Add ability to renderJson() which takes either and object or a json string and renders it within a <pre> tag.
-    * Add ability to renderHtml() which takes string html and renders it within a <pre> tag.
-    * Add ability to renderCode() which takes string of code and renders it within a <pre> tag.
-* 1.4.2
-    * Add style for fs-hr-dotted hr classes.
-* 1.4.1
-    * Updates to documentation
-* 1.4.0
-    * Update the debugger.phtml panel to use new renderTrace() helper method to render the trace for each debugger.
-    * Remove the $echo parameter option from Fire\Bug::render method. By default this method will now return the rendered panel by default.
-* 1.3.0
-    * Add renderTrace() helper method to render a standard debug_backtrace() within a panel phtml template.
-* 1.2.0
-    * Remove composer.lock as it is not needed because this is a library.
-    * Add overflow-x css rule for fs-content to allow tables to be scrollable. .fs-debug-panel .fs-section .fs-content overflow-x: scroll
-* 1.1.1
-    * Fix issue where we couldn't see load time on debug panel.
-* 1.1.0
-    * Stronger style selectors so that website styles don't overwrite panel styles.
-    * Remove any instance where we are trying to set a constant using the __DIR__ magic variable. ex: const MYCONSTANT = __DIR__ . '/path.php'
-    * On view/panels/debugger.phtml, add logic to check if $trace['file'] and $trace['line'] are not empty.
-    * Add "Steps To Create Release" to RELEASE.md
-    * On Fire\Bug::render(), allow a developer to pass in a parameter that determines if we should return the HTML or echo it.
-    * The count of the number of debuggers in the debugger accordion. example: Debuggers (12)
-    * Add hr styles for panel to include styles margin: 25px 0; color: #464646; border-top: 2px dashed; background-color: #f0f0f0;.
-    * Add hr separator between debuggers.
-* 1.0.0
-    * Initial Release

--- a/UA1Labs/Fire/Bug.TestCase.php
+++ b/UA1Labs/Fire/Bug.TestCase.php
@@ -17,6 +17,7 @@ use \UA1Labs\Fire\Test\TestCase;
 use \UA1Labs\Fire\Bug as FireBug;
 use \UA1Labs\Fire\Bug\Panel\Debugger as DebuggerPanel;
 use \UA1Labs\Fire\BugException;
+use \UA1Labs\Fire\Bug\Panel;
 
 /**
  * Test Suite for Fire\Bug.
@@ -83,6 +84,19 @@ class BugTestCase extends TestCase
         }
         $this->should('A Fire\BugException should be thown when trying to add a panel with a duplicate id.');
         $this->assert(isset($exception) && $exception instanceof BugException);
+
+        $this->should('Test that firebug panels are returned in the order they have been set by.');
+        $mockPanel = $this->getMockObject(Panel::class, [
+            'getId' => 'TestDebugPanel'
+        ]);
+        $panelOrder = [
+            'TestDebugPanel',
+            DebuggerPanel::ID
+        ];
+        $fireBug->addPanel($mockPanel);
+        $fireBug->setPanelOrder($panelOrder);
+        $panels = $fireBug->getPanels();
+        $this->assert(array_keys($panels) === $panelOrder);
     }
 
     /**

--- a/UA1Labs/Fire/Bug.php
+++ b/UA1Labs/Fire/Bug.php
@@ -58,6 +58,13 @@ final class Bug extends Panel
     private $panels;
 
     /**
+     * An array of panel IDs in the order you want them to display.
+     *
+     * @var array<string>
+     */
+    private $panelOrder;
+
+    /**
      * The class constructor.
      */
     public function __construct()
@@ -119,7 +126,7 @@ final class Bug extends Panel
     {
         $id = $panel->getId();
         if (!empty($this->panels[$id])) {
-            throw new BugException('[FireBug] No panels exist with ID "' . $id . '".');
+            throw new BugException('A panel already exists with ID "' . $id . '".');
         }
         $this->panels[$id] = $panel;
     }
@@ -142,7 +149,28 @@ final class Bug extends Panel
      */
     public function getPanels()
     {
-        return $this->panels;
+        if (!$this->panelOrder) {
+            return $this->panels;
+        }
+
+        $panels = [];
+        foreach ($this->panelOrder as $panelId) {
+            if (isset($this->panels[$panelId])) {
+                $panels[$panelId] = $this->panels[$panelId];
+            }
+        }
+        
+        return $panels;
+    }
+
+    /**
+     * Sets the order in which you want to see the panels.
+     *
+     * @param array<string> $panelOrder An array of panel ids
+     */
+    public function setPanelOrder($panelOrder)
+    {
+        $this->panelOrder = $panelOrder;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ua1-labs/firebug",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "An expandable PHP debugger panel.",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Up and until now, users of FireBug would only be able to set the display order for debug panels by the order in which they are registered. We fixed that by adding a `setPanelOrder` to the `\UA1Labs\Fire\Bug` object.